### PR TITLE
Use std:numeric limits in dataref instead of INT_MAX and CHAR_MAX

### DIFF
--- a/src/dataref.cpp
+++ b/src/dataref.cpp
@@ -340,7 +340,7 @@ void DataRef<std::vector<int> >::forceChanged()
     if (m_history.size() != actual.size())
         return;
     for (std::size_t i = 0; i < m_history.size() ; ++i)
-        m_history[i] = INT_MAX;
+        m_history[i] = std::numeric_limits<int>::max();
 }
 
 template <>
@@ -360,7 +360,7 @@ void DataRef<std::string>::forceChanged()
     if (m_history.size() != actual.size())
         return;
     for (std::size_t i = 0; i < m_history.size() ; ++i)
-        m_history[i] = CHAR_MAX;
+        m_history[i] = std::numeric_limits<char>::max();
 }
 
 

--- a/src/dataref.h
+++ b/src/dataref.h
@@ -51,7 +51,7 @@ const char* const DRE_PLUGIN_SINATURE = "xplanesdk.examples.DataRefEditor";
   *
   * For simdata, it specifies if incoming data may be written to X-Plane
   * and if data should be readable.
-  * For owned data, it specifies if the data is readable or writebale
+  * For owned data, it specifies if the data is readable or writeable
   * to OTHER plugins (or anything that accesses datarefs e.g. panels).
   * @todo Should there be two enums for simdata and owned data?
   */


### PR DESCRIPTION
Error:
```
error: ‘INT_MAX’ was not declared in this scope
         m_history[i] = INT_MAX;
...
error: ‘CHAR_MAX’ was not declared in this scope
         m_history[i] = CHAR_MAX;
```

INT_MAX and CHAR_MAX are defined in the C header: <climits> (limits.h).
Use C++ numeric_limits instead.